### PR TITLE
fix crc calc for non-express boards

### DIFF
--- a/adafruit_lc709203f.py
+++ b/adafruit_lc709203f.py
@@ -171,7 +171,8 @@ class LC709203F:
                     crc = (crc << 1) ^ 0x07
                 else:
                     crc <<= 1
-        return crc & 0xFF
+                crc &= 0xFF
+        return crc
 
     def _read_word(self, command):
         self._buf[0] = LC709203F_I2CADDR_DEFAULT * 2  # write byte


### PR DESCRIPTION
Bug fix for non-Express boards. Library works on Express CircuitPython boards where an [integer doesn't have an upper bound](https://learn.adafruit.com/circuitpython-essentials/circuitpython-expectations), but on non-express boards, like the QT Py M0, int has an upper bound that is getting overflowed and throwing an exception.  This fix drops bits above a byte on each CRC calc change to prevent the overflow (which was probably happening in C anyway).

Fix to issue brought up on this forum topic: [QTPyM0: "small int overflow" on CRC calc w lc709203](https://forums.adafruit.com/viewtopic.php?f=60&t=176416#wrap) 