### PR TITLE
Add thermistor support

### DIFF
--- a/adafruit_lc709203f.py
+++ b/adafruit_lc709203f.py
@@ -123,12 +123,12 @@ class LC709203F:
     def cell_percent(self):
         """Returns percentage of cell capacity"""
         return self._read_word(LC709203F_CMD_CELLITE) / 10
-       
+
     @property
     def cell_temperature(self):
         """Returns the temperature of the cell"""
         return self._read_word(LC709203F_CMD_CELLTEMPERATURE) / 10 - 273.15
-    
+
     @cell_temperature.setter
     def cell_temperature(self, value):
         """Sets the temperature in the LC709203F"""
@@ -173,28 +173,28 @@ class LC709203F:
         if not PackSize.is_valid(size):
             raise AttributeError("pack_size must be a PackSize")
         self._write_word(LC709203F_CMD_APA, size)
-        
+
     @property
     def thermistor_bconstant(self):
         """Returns the thermistor B-constant"""
         return self._read_word(LC709203F_CMD_THERMISTORB)
-    
+
     @thermistor_bconstant.setter
-    def thermistor_bconstant(self,bconstant):
+    def thermistor_bconstant(self, bconstant):
         """Sets the thermistor B-constant"""
         self._write_word(LC709203F_CMD_THERMISTORB, bconstant)
-        
+
     @property
     def thermistor_enable(self):
         """Returns the current temperature source"""
         return self._read_word(LC709203F_CMD_STATUSBIT)
-        
+
     @thermistor_enable.setter
-    def thermistor_enable(self,status):
+    def thermistor_enable(self, status):
         """Sets the temperature source to Tsense"""
         if not status in (True, False):
             raise AttributeError("thermistor_enable must be True or False")
-        self._write_word(LC709203F_CMD_STATUSBIT,status)
+        self._write_word(LC709203F_CMD_STATUSBIT, status)
 
     # pylint: disable=no-self-use
     def _generate_crc(self, data):

--- a/adafruit_lc709203f.py
+++ b/adafruit_lc709203f.py
@@ -41,6 +41,9 @@ LC709203F_CMD_APA = const(0x0B)
 LC709203F_CMD_INITRSOC = const(0x07)
 LC709203F_CMD_CELLVOLTAGE = const(0x09)
 LC709203F_CMD_CELLITE = const(0x0F)
+LC709203F_CMD_CELLTEMPERATURE = const(0x08)
+LC709203F_CMD_THERMISTORB = const(0x06)
+LC709203F_CMD_STATUSBIT = const(0x16)
 
 
 class CV:
@@ -120,6 +123,18 @@ class LC709203F:
     def cell_percent(self):
         """Returns percentage of cell capacity"""
         return self._read_word(LC709203F_CMD_CELLITE) / 10
+       
+    @property
+    def cell_temperature(self):
+        """Returns the temperature of the cell"""
+        return self._read_word(LC709203F_CMD_CELLTEMPERATURE) / 10 - 273.15
+    
+    @cell_temperature.setter
+    def cell_temperature(self, value):
+        """Sets the temperature in the LC709203F"""
+        if self.thermistor_enable:
+            raise AttributeError("temperature can only be set in i2c mode")
+        self._write_word(LC709203F_CMD_CELLTEMPERATURE, int(value + 273.15) * 10)
 
     @property
     def ic_version(self):
@@ -158,6 +173,28 @@ class LC709203F:
         if not PackSize.is_valid(size):
             raise AttributeError("pack_size must be a PackSize")
         self._write_word(LC709203F_CMD_APA, size)
+        
+    @property
+    def thermistor_bconstant(self):
+        """Returns the thermistor B-constant"""
+        return self._read_word(LC709203F_CMD_THERMISTORB)
+    
+    @thermistor_bconstant.setter
+    def thermistor_bconstant(self,bconstant):
+        """Sets the thermistor B-constant"""
+        self._write_word(LC709203F_CMD_THERMISTORB, bconstant)
+        
+    @property
+    def thermistor_enable(self):
+        """Returns the current temperature source"""
+        return self._read_word(LC709203F_CMD_STATUSBIT)
+        
+    @thermistor_enable.setter
+    def thermistor_enable(self,status):
+        """Sets the temperature source to Tsense"""
+        if not status in (True, False):
+            raise AttributeError("thermistor_enable must be True or False")
+        self._write_word(LC709203F_CMD_STATUSBIT,status)
 
     # pylint: disable=no-self-use
     def _generate_crc(self, data):

--- a/examples/lc709203f_thermistortest.py
+++ b/examples/lc709203f_thermistortest.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Daniel Griswold
 #
 # SPDX-License-Identifier: MIT
- 
+
 import time
 import board
 from adafruit_lc709203f import LC709203F
@@ -17,7 +17,5 @@ sensor.thermistor_enable = True
 
 print("IC version:", hex(sensor.ic_version))
 while True:
-    print(
-        "Cell Temperature: %0.2f C" % (sensor.cell_temperature)
-    )
+    print("Cell Temperature: %0.2f C" % (sensor.cell_temperature))
     time.sleep(1)

--- a/examples/lc709203f_thermistortest.py
+++ b/examples/lc709203f_thermistortest.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Daniel Griswold
+#
+# SPDX-License-Identifier: MIT
+ 
 import time
 import board
 from adafruit_lc709203f import LC709203F

--- a/examples/lc709203f_thermistortest.py
+++ b/examples/lc709203f_thermistortest.py
@@ -1,0 +1,19 @@
+import time
+import board
+from adafruit_lc709203f import LC709203F
+
+print("LC709203F thermistor test")
+print("Make sure a thermistor is connected to the board!")
+
+sensor = LC709203F(board.I2C())
+
+# check your NTC thermistor datasheet for the appropriate B-Constant
+sensor.thermistor_bconstant = 3950
+sensor.thermistor_enable = True
+
+print("IC version:", hex(sensor.ic_version))
+while True:
+    print(
+        "Cell Temperature: %0.2f C" % (sensor.cell_temperature)
+    )
+    time.sleep(1)


### PR DESCRIPTION
Added support for thermistors and setting the cell temperature over i2c.

For the b-constant, the sensor expects an integer with the unit of 1k. (so 3950K is 3950)

For the cell_temperature, the registers hold the Kelvin temperature.  I'm converting to and from Celsius.  If this is not desired in the library, I can remove the conversion.