### PR TITLE
add retries and delays to work around ESP32-S3 problems

### DIFF
--- a/examples/lc709203f_simpletest.py
+++ b/examples/lc709203f_simpletest.py
@@ -13,7 +13,12 @@ sensor = LC709203F(board.I2C())
 
 print("IC version:", hex(sensor.ic_version))
 while True:
-    print(
-        "Battery: %0.3f Volts / %0.1f %%" % (sensor.cell_voltage, sensor.cell_percent)
-    )
+    try:
+        print(
+            "Battery: %0.3f Volts / %0.1f %%"
+            % (sensor.cell_voltage, sensor.cell_percent)
+        )
+    except OSError:
+        print("retry reads")
+
     time.sleep(1)


### PR DESCRIPTION
ESP32-S3 has some issues with the clock-stretching and sleeping done by the LC709203F. See https://github.com/adafruit/circuitpython/issues/6311.

- Add retries when scanning for the device, and also add some delays during setup. This seems to mostly ameliorate the problems on the S3.
- Raise `ValueError` for bad args, not `AttributeError`.
- Raise `OSError` instead of `RuntimeError` on CRC failure. This makes it easier to catch all read/write failures so you can retry.

Tested with this program. Note the `try`-`except` which catches `OSError`. There can still be occasional failures, so it's good to catch and retry.

```py
import time
import board
import busio
from adafruit_lc709203f import LC709203F, PackSize

uart = board.UART()
battery_monitor = LC709203F(board.I2C())
battery_monitor.pack_size = PackSize.MAH400

while True:
    try:
        print("Battery Percent: {:.2f} %".format(battery_monitor.cell_percent))
        print("Battery Voltage: {:.2f} V".format(battery_monitor.cell_voltage))

        uart.write(b"Battery Percent: {:.2f} %\r\n".format(battery_monitor.cell_percent))
        uart.write(b"Battery Voltage: {:.2f} V\r\n".format(battery_monitor.cell_voltage))
    except OSError:
        print("retrying reads")

    time.sleep(2)
```

@Gingertrout @BeatArnet @mopore @ThomasAtBBTF Could you try this changed version and see if it works for you? Thank you. You just need to copy the `adafruit_lc709203f.py` file in this pull request to your CIRCUITPY drive, which will override what is in your `lib/`. You should be able to remove the `i2c.scan()` code from your existing programs, since this does approximately the same thing.

New code is available at https://github.com/adafruit/Adafruit_CircuitPython_LC709203F/blob/1007e4c96bc465204de0cb5a3684022e9e0fb71b/adafruit_lc709203f.py