### PR TITLE
Add error checking and retries to the read and write functions

### DIFF
--- a/adafruit_lc709203f.py
+++ b/adafruit_lc709203f.py
@@ -286,17 +286,19 @@ class LC709203F:
             try:
                 with self.i2c_device as i2c:
                     i2c.write_then_readinto(self._buf, self._buf, out_start=1, out_end=2, in_start=3, in_end=7)
-                break
+                    
+                crc8 = self._generate_crc(self._buf[0:5])
+                if crc8 != self._buf[5]:
+                    raise OSError("CRC failure on reading word")
+                return (self._buf[4] << 8) | self._buf[3]
             except OSError as e:
+                #print("OSError: ", x, "/10: ", e)
                 pass
             if x == (LC709203F_I2C_RETRY_COUNT-1):
                 #Retry count reached
                 raise e
         
-        crc8 = self._generate_crc(self._buf[0:5])
-        if crc8 != self._buf[5]:
-            raise OSError("CRC failure on reading word")
-        return (self._buf[4] << 8) | self._buf[3]
+        
 
     def _write_word(self, command: int, data: int) -> None:
         self._buf[0] = LC709203F_I2CADDR_DEFAULT * 2  # write byte
@@ -311,6 +313,7 @@ class LC709203F:
                     i2c.write(self._buf[1:5])
                 return
             except OSError as e:
+                #print("OSError: ", x, "/10: ", e)
                 pass
                 
         #Retry count reached

--- a/adafruit_lc709203f.py
+++ b/adafruit_lc709203f.py
@@ -158,18 +158,27 @@ class LC709203F:
     @property
     def cell_voltage(self) -> float:
         """Returns floating point voltage"""
-        return self._read_word(LC709203F_CMD_CELLVOLTAGE) / 1000
-
+        try:
+            return self._read_word(LC709203F_CMD_CELLVOLTAGE) / 1000
+        except OSError:
+            return None
+            
     @property
     def cell_percent(self) -> float:
         """Returns percentage of cell capacity"""
-        return self._read_word(LC709203F_CMD_CELLITE) / 10
-
+        try:
+            return self._read_word(LC709203F_CMD_CELLITE) / 10
+        except OSError:
+            return None
+            
     @property
     def cell_temperature(self) -> float:
         """Returns the temperature of the cell"""
-        return self._read_word(LC709203F_CMD_CELLTEMPERATURE) / 10 - 273.15
-
+        try:
+            return self._read_word(LC709203F_CMD_CELLTEMPERATURE) / 10 - 273.15
+        except OSError:
+            return None
+            
     @cell_temperature.setter
     def cell_temperature(self, value: float) -> None:
         """Sets the temperature in the LC709203F"""
@@ -300,12 +309,12 @@ class LC709203F:
                     raise OSError("CRC failure on reading word")
                 return (self._buf[4] << 8) | self._buf[3]
             except OSError as exception:
-                # print("OSError: ", x, "/10: ", exception)
+                print("OSError in read: ", x, "/10: ", exception)
                 if x == (LC709203F_I2C_RETRY_COUNT - 1):
                     # Retry count reached
                     raise exception
 
-        # Code should never reach this point
+        # Code should never reach this point, add this to satisfy pylint R1710.
         return None
 
     def _write_word(self, command: int, data: int) -> None:
@@ -314,7 +323,6 @@ class LC709203F:
         self._buf[2] = data & 0xFF
         self._buf[3] = (data >> 8) & 0xFF
         self._buf[4] = self._generate_crc(self._buf[0:4])
-        # exception = None
 
         for x in range(LC709203F_I2C_RETRY_COUNT):
             try:
@@ -322,10 +330,7 @@ class LC709203F:
                     i2c.write(self._buf[1:5])
                 return
             except OSError as exception:
-                # print("OSError: ", x, "/10: ", exception)
+                print("OSError in write: ", x, "/10: ", exception)
                 if x == (LC709203F_I2C_RETRY_COUNT - 1):
                     # Retry count reached
                     raise exception
-
-        # Retry count reached
-        # raise exception

--- a/adafruit_lc709203f.py
+++ b/adafruit_lc709203f.py
@@ -162,7 +162,7 @@ class LC709203F:
             return self._read_word(LC709203F_CMD_CELLVOLTAGE) / 1000
         except OSError:
             return None
-            
+
     @property
     def cell_percent(self) -> float:
         """Returns percentage of cell capacity"""
@@ -170,7 +170,7 @@ class LC709203F:
             return self._read_word(LC709203F_CMD_CELLITE) / 10
         except OSError:
             return None
-            
+
     @property
     def cell_temperature(self) -> float:
         """Returns the temperature of the cell"""
@@ -178,7 +178,7 @@ class LC709203F:
             return self._read_word(LC709203F_CMD_CELLTEMPERATURE) / 10 - 273.15
         except OSError:
             return None
-            
+
     @cell_temperature.setter
     def cell_temperature(self, value: float) -> None:
         """Sets the temperature in the LC709203F"""
@@ -309,9 +309,10 @@ class LC709203F:
                     raise OSError("CRC failure on reading word")
                 return (self._buf[4] << 8) | self._buf[3]
             except OSError as exception:
-                print("OSError in read: ", x, "/10: ", exception)
+                # print("OSError in read: ", x+1, "/10: ", exception)
                 if x == (LC709203F_I2C_RETRY_COUNT - 1):
                     # Retry count reached
+                    # print("Retry count reached in read: ", exception)
                     raise exception
 
         # Code should never reach this point, add this to satisfy pylint R1710.
@@ -330,7 +331,8 @@ class LC709203F:
                     i2c.write(self._buf[1:5])
                 return
             except OSError as exception:
-                print("OSError in write: ", x, "/10: ", exception)
+                # print("OSError in write: ", x+1, "/10: ", exception)
                 if x == (LC709203F_I2C_RETRY_COUNT - 1):
                     # Retry count reached
+                    # print("Retry count reached in write: ", exception)
                     raise exception


### PR DESCRIPTION
I am having issues with read errors on 

`Adafruit CircuitPython 9.2.1 on 2024-11-20; Adafruit Feather ESP32S3 4MB Flash 2MB PSRAM with ESP32S3`

See [here](https://github.com/adafruit/circuitpython/issues/6311#issuecomment-2543969760) for more details. 

I added try/except and retry to the `_read_word` and `_write_word` functions. I also added a check to the `cell_voltage`, `cell_percent`, and `cell_temperature` functions that will catch an error in a read during those functions and return `none` if the read fails. It will be up to the user to decide what they want to do when that happens, but it won't crash user code. (probably)

My experiences with these errors:
- The errors happen more often the more quickly you read data from the device. (as in how fast you call the `cell_voltage` function.)
- Most of these error are cleared up with a single retry.
- It will occasionally fail 10 times in a row, so the added try/except in the read functions is necessary.


Possible Improvements:
- Allow the user to set the number of retries.
- Add try/except to other functions.